### PR TITLE
update parser to read date from file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wnc-copwatch",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "JavaScript app that makes tracking police activity easy",
   "main": "server.js",
   "scripts": {

--- a/tests/dateParser.test.js
+++ b/tests/dateParser.test.js
@@ -74,3 +74,12 @@ it("Doesn't return 1970 (v5)", () => {
     dateParser("on 18:20, 2/23/2018. Reported: 18:20, 2/23/2018.").getFullYear()
   ).toBeGreaterThan(1970)
 })
+
+/*
+ * '2018-10-10' - formatted from file name
+ */
+it("Parses dates from filenames (2018-10-10)", () => {
+  expect(
+    dateParser('2018-10-10')
+  ).toBeInstanceOf(Date)
+})

--- a/utils/dateParser.js
+++ b/utils/dateParser.js
@@ -1,4 +1,9 @@
 /*
+ * TODO: All but the last clause can be removed with next full version.
+ *       Dates are no longer parsed from bulletins but read from filename
+ *
+ * @deprecated since version 0.6
+ *
  * Dates in police bulletins can vary quite a bit. Each case has an example of
  * the type of string it is capable of parsing a valid Date object from.
  * This is probably not exhaustive.
@@ -9,27 +14,34 @@
  * Date object and another to verify it isn't POSIX year 0.
  */
 
-// dateParser :: String -> Date
+// dateParser :: String -> Date`${d}/${m}/${y}`
 const dateParser = date => {
+  console.warn("function 'dateParser()' is deprecated as of v0.6.0 and will be removed/refactored in the next release")
+
+  // ' between 00:40, 3/5/2018 and 00:40, 3/5/2018. Reported: 00:40, 3/5/2018.'
   if (date.includes('between')) {
-    // ' between 00:40, 3/5/2018 and 00:40, 3/5/2018. Reported: 00:40, 3/5/2018.'
     return new Date(date.substring(date.indexOf('.') + 19))
 
+  // ' on 18:20, 2/23/2018. Reported: 18:20, 2/23/2018.'
   } else if (date[6] == ':') {
-    // ' on 18:20, 2/23/2018. Reported: 18:20, 2/23/2018.'
     return new Date(date.substring(10, 20))
 
+  // 'on 18:20, 2/23/2018. Reported: 18:20, 2/23/2018.'
   } else if (date[5] == ':') {
-    // 'on 18:20, 2/23/2018. Reported: 18:20, 2/23/2018.'
     return new Date(date.substring(9, 19))
 
+  // ' on 3/5/2018 02:20.'
   } else if (date[0] == ' ') {
-    // ' on 3/5/2018 02:20.'
     return new Date(date.substring(2, 13))
 
+  // 'On 3/5/2018 10:12:04 AM at 10:12'
   } else if ((date[0] == 'o') || (date[0] == 'O')) {
-    // 'On 3/5/2018 10:12:04 AM at 10:12'
     return new Date(date.substring(3, 12))
+
+  // '2018-10-10'
+  } else if (date.length == 10) {
+    const [y, m, d] = date.split('-')
+    return new Date(`${m}/${d}/${y}`)
   }
 }
 

--- a/utils/parser.js
+++ b/utils/parser.js
@@ -15,8 +15,9 @@ const winston = require('../config/winston')
 const geoLocation = require('./geoLocation')
 const dateParser = require('./dateParser')
 const report = ('../models/report')
-const filePath = path.join(__dirname, `../reports/${process.argv[2]}`)
-const force = process.argv[2].substr(0, process.argv[2].indexOf('.'))
+const fileName = process.argv[2]
+const filePath = path.join(__dirname, `../reports/${fileName}`)
+const [force, date, type] = fileName.split('.') // ex. [apd, 2018-10-10, xls]
 
 MongoClient.connect(process.env.DB_URL, (err, client) => {
   if (err) {
@@ -34,7 +35,7 @@ MongoClient.connect(process.env.DB_URL, (err, client) => {
       'code': e[0],
       'description': e[4],
       'address': e[5].slice(4, e[5].length),
-      'dateTime': dateParser(e[6]),
+      'dateTime': dateParser(date),
       'race': e[11],
       'officer': e[8],
     }))


### PR DESCRIPTION
`parser.js` used to get the date from the police bulletins. This was error-prone as dates were never entered consistently and many variations had to be taken into account and ended up breaking when the date grew a digit longer (from 10/9/2018 to 10/10/2018). `parser.js` now sets the reports' dates based on the filename.